### PR TITLE
Add parent and recipe generation modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>ca.derekcormier</groupId>
+    <artifactId>recipe</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+    
+    <modules>
+        <module>recipe-generation</module>
+    </modules>
+</project>

--- a/recipe-generation/pom.xml
+++ b/recipe-generation/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>recipe</artifactId>
+        <groupId>ca.derekcormier</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>recipe-generation</artifactId>
+
+    <dependencies>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/recipe-generation/src/main/java/ca/derekcormier/recipe/parser/Domain.java
+++ b/recipe-generation/src/main/java/ca/derekcormier/recipe/parser/Domain.java
@@ -1,0 +1,26 @@
+package ca.derekcormier.recipe.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Domain {
+    private List<Entity> entities = new ArrayList<>();
+    private List<Enum> enums = new ArrayList<>();
+
+
+    public void addEntity(Entity entity) {
+        this.entities.add(entity);
+    }
+
+    public void addEnum(Enum enumeration) {
+        this.enums.add(enumeration);
+    }
+
+    public List<Entity> getEntities() {
+        return entities;
+    }
+
+    public List<Enum> getEnums() {
+        return enums;
+    }
+}

--- a/recipe-generation/src/main/java/ca/derekcormier/recipe/parser/DomainXMLParser.java
+++ b/recipe-generation/src/main/java/ca/derekcormier/recipe/parser/DomainXMLParser.java
@@ -1,0 +1,100 @@
+package ca.derekcormier.recipe.parser;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import java.io.*;
+import java.net.URL;
+
+public class DomainXMLParser {
+    public static void validateXml(InputStream xmlStream) {
+        try {
+            SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            URL url = DomainXMLParser.class.getClassLoader().getResource("domain-schema.xsd");
+            Schema schema = schemaFactory.newSchema(url);
+            Validator validator = schema.newValidator();
+            validator.validate(new StreamSource(xmlStream));
+        } catch (SAXException e) {
+            throw new ParseException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Domain parseXml(InputStream xmlStream) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(xmlStream);
+            doc.getDocumentElement().normalize();
+
+            Domain domain = new Domain();
+
+            Element domainElement = (Element)doc.getElementsByTagName("domain").item(0);
+            NodeList entities = domainElement.getElementsByTagName("entity");
+            for (int i = 0; i < entities.getLength(); i++) {
+                Entity entity = parseEntity((Element)entities.item(i));
+                domain.addEntity(entity);
+            }
+
+            NodeList enums = domainElement.getElementsByTagName("enum");
+            for (int i = 0; i < enums.getLength(); i++) {
+                Enum enumEntity = parseEnum((Element)enums.item(i));
+                domain.addEnum(enumEntity);
+            }
+
+            return domain;
+        } catch (ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        } catch (SAXException e) {
+            throw new ParseException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Entity parseEntity(Element entityElement) {
+        String name = entityElement.getAttribute("name");
+        Entity entity = new Entity(name);
+
+
+        NodeList properties = entityElement.getElementsByTagName("property");
+        for (int i = 0; i < properties.getLength(); i++) {
+            Element propertyElement = (Element)properties.item(i);
+            Property property = parseProperty(propertyElement);
+            entity.addProperty(property);
+        }
+
+        return entity;
+    }
+
+    private static Property parseProperty(Element propertyElement) {
+        String name = propertyElement.getAttribute("name");
+        String type = propertyElement.getAttribute("type");
+        boolean required = propertyElement.hasAttribute("required") && propertyElement.getAttribute("required").equals("true");
+
+        return new Property(name, type, required);
+    }
+
+    private static Enum parseEnum(Element enumElement) {
+        String name = enumElement.getAttribute("name");
+        Enum enumeration = new Enum(name);
+
+        NodeList values = enumElement.getElementsByTagName("value");
+        for (int i = 0; i < values.getLength(); i++) {
+            enumeration.addValue(values.item(i).getTextContent());
+        }
+
+        return enumeration;
+    }
+}

--- a/recipe-generation/src/main/java/ca/derekcormier/recipe/parser/Entity.java
+++ b/recipe-generation/src/main/java/ca/derekcormier/recipe/parser/Entity.java
@@ -1,0 +1,25 @@
+package ca.derekcormier.recipe.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Entity {
+    private String name;
+    private List<Property> properties = new ArrayList<>();
+
+    public Entity(String name) {
+        this.name = name;
+    }
+
+    public void addProperty(Property property) {
+        this.properties.add(property);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<Property> getProperties() {
+        return properties;
+    }
+}

--- a/recipe-generation/src/main/java/ca/derekcormier/recipe/parser/Enum.java
+++ b/recipe-generation/src/main/java/ca/derekcormier/recipe/parser/Enum.java
@@ -1,0 +1,25 @@
+package ca.derekcormier.recipe.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Enum {
+    private String name;
+    private List<String> values = new ArrayList<>();
+
+    public Enum(String name) {
+        this.name = name;
+    }
+
+    public void addValue(String value) {
+        values.add(value);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<String> getValues() {
+        return values;
+    }
+}

--- a/recipe-generation/src/main/java/ca/derekcormier/recipe/parser/ParseException.java
+++ b/recipe-generation/src/main/java/ca/derekcormier/recipe/parser/ParseException.java
@@ -1,0 +1,7 @@
+package ca.derekcormier.recipe.parser;
+
+public class ParseException extends RuntimeException {
+    public ParseException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/recipe-generation/src/main/java/ca/derekcormier/recipe/parser/Property.java
+++ b/recipe-generation/src/main/java/ca/derekcormier/recipe/parser/Property.java
@@ -1,0 +1,25 @@
+package ca.derekcormier.recipe.parser;
+
+public class Property {
+    private String name;
+    private boolean required;
+    private String type;
+
+    public Property(String name, String type, boolean required) {
+        this.name = name;
+        this.type = type;
+        this.required = required;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/recipe-generation/src/main/resources/domain-schema.xsd
+++ b/recipe-generation/src/main/resources/domain-schema.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="domain">
+        <xs:complexType>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="entity">
+                    <xs:complexType>
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="property">
+                                <xs:complexType>
+                                    <xs:attribute name="name" type="xs:string" use="required"/>
+                                    <xs:attribute name="type" type="xs:string" use="required"/>
+                                    <xs:attribute name="required" type="xs:boolean" default="true"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:choice>
+                        <xs:attribute name="name" type="xs:string" use="required"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="enum">
+                    <xs:complexType>
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="value" type="xs:string"/>
+                        </xs:choice>
+                        <xs:attribute name="name" type="xs:string" use="required"/>
+                    </xs:complexType>
+                    <!-- Enum values unique per enum -->
+                    <xs:unique name="UniqueEnumValue">
+                        <xs:selector xpath="value"/>
+                        <xs:field xpath="."/>
+                    </xs:unique>
+                </xs:element>
+            </xs:choice>
+        </xs:complexType>
+
+        <!-- Entity names unique -->
+        <xs:unique name="UniqueEntityName">
+            <xs:selector xpath="entity"/>
+            <xs:field xpath="@name" />
+        </xs:unique>
+        <!-- Property names unique per entity -->
+        <xs:unique name="UniquePropertyName">
+            <xs:selector xpath="entity/property"/>
+            <xs:field xpath="@name" />
+        </xs:unique>
+    </xs:element>
+</xs:schema>

--- a/recipe-generation/src/test/java/parsing/DomainXMLParserTest.java
+++ b/recipe-generation/src/test/java/parsing/DomainXMLParserTest.java
@@ -1,0 +1,218 @@
+package parsing;
+
+import ca.derekcormier.recipe.parser.Domain;
+import ca.derekcormier.recipe.parser.DomainXMLParser;
+import ca.derekcormier.recipe.parser.ParseException;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DomainXMLParserTest {
+    @Test
+    public void testValidateXml_emptyDomainPasses() {
+        DomainXMLParser.validateXml(getStringStream(String.join("\n",
+            "<domain>",
+            "</domain>"
+        )));
+    }
+
+    @Test(expected = ParseException.class)
+    public void testValidateXml_multipleDomainsFail() {
+        DomainXMLParser.validateXml(getStringStream(String.join("\n",
+            "<domain>",
+            "</domain>",
+            "<domain>",
+            "</domain>"
+        )));
+    }
+
+    @Test
+    public void testValidateXml_validXmlPasses() {
+        DomainXMLParser.validateXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<entity name='TestEntity'>",
+                    "<property name='a' type='int' required='true'/>",
+                    "<property name='b' type='string' required='true'/>",
+                "</entity>",
+                "<enum name='TestEnum'>",
+                    "<value>A</value>",
+                    "<value>B</value>",
+                    "<value>C</value>",
+                "</enum>",
+            "</domain>"
+        )));
+    }
+
+    @Test(expected = ParseException.class)
+    public void testValidateXml_entityWithNoNameFails() {
+        DomainXMLParser.validateXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<entity></entity>",
+            "</domain>"
+        )));
+    }
+
+    @Test(expected = ParseException.class)
+    public void testValidateXml_propertyWithNoNameFails() {
+        DomainXMLParser.validateXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<entity name='TestEntity'>",
+                    "<property type='string'/>",
+                "</entity>",
+            "</domain>"
+        )));
+    }
+
+    @Test(expected = ParseException.class)
+    public void testValidateXml_entitiesWithSameNameFails() {
+        DomainXMLParser.validateXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<entity name='TestEntity'></entity>",
+                "<entity name='TestEntity'></entity>",
+            "</domain>"
+        )));
+    }
+
+    @Test(expected = ParseException.class)
+    public void testValidateXml_propertiesWithSameNameInEntityFails() {
+        DomainXMLParser.validateXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<entity name='TestEntity'>",
+                    "<property name='a' type='int' required='true'/>",
+                    "<property name='a' type='string' required='true'/>",
+                "</entity>",
+            "</domain>"
+        )));
+    }
+
+    @Test(expected = ParseException.class)
+    public void testValidateXml_propertiesWithSameNameInDifferentEntitiesPasses() {
+        DomainXMLParser.validateXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<entity name='A'>",
+                    "<property name='a' type='int'/>",
+                "</entity>",
+                "<entity name='B'>",
+                    "<property name='a' type='int'/>",
+                "</entity>",
+            "</domain>"
+        )));
+    }
+
+    @Test(expected = ParseException.class)
+    public void testValidateXml_enumsWithDuplicateValuesFails() {
+        DomainXMLParser.validateXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<enum name='TestEnum'>",
+                    "<value>A</value>",
+                    "<value>A</value>",
+                "</enum>",
+            "</domain>"
+        )));
+    }
+
+    @Test
+    public void testValidateXml_sameEnumValuesAcrossDifferentEnumsPasses() {
+        DomainXMLParser.validateXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<enum name='TestEnum1'>",
+                    "<value>A</value>",
+                "</enum>",
+                "<enum name='TestEnum2'>",
+                    "<value>A</value>",
+                "</enum>",
+            "</domain>"
+        )));
+    }
+
+    @Test
+    public void testParseXml_parsesEmptyDomain() {
+        Domain domain = DomainXMLParser.parseXml(getStringStream(String.join("\n",
+            "<domain>",
+            "</domain>"
+        )));
+
+        assertEquals(0, domain.getEntities().size());
+    }
+
+    @Test
+    public void testParseXml_parsesEntity() {
+        Domain domain = DomainXMLParser.parseXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<entity name='TestEntity'>",
+                "</entity>",
+            "</domain>"
+        )));
+
+        assertEquals(1, domain.getEntities().size());
+        assertEquals("TestEntity", domain.getEntities().get(0).getName());
+        assertEquals(0, domain.getEntities().get(0).getProperties().size());
+    }
+
+    @Test
+    public void testParseXml_parsesProperty() {
+        Domain domain = DomainXMLParser.parseXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<entity name='TestEntity'>",
+                    "<property name='TestProperty' type='string'/>",
+                "</entity>",
+            "</domain>"
+        )));
+
+        assertEquals(1, domain.getEntities().get(0).getProperties().size());
+        assertEquals("TestProperty", domain.getEntities().get(0).getProperties().get(0).getName());
+        assertEquals("string", domain.getEntities().get(0).getProperties().get(0).getType());
+        assertEquals(false, domain.getEntities().get(0).getProperties().get(0).isRequired());
+    }
+
+    @Test
+    public void testParseXml_parsesProperty_required() {
+        Domain domain = DomainXMLParser.parseXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<entity name='TestEntity'>",
+                    "<property name='TestProperty' type='string' required='true'/>",
+                "</entity>",
+            "</domain>"
+        )));
+
+        assertEquals(1, domain.getEntities().get(0).getProperties().size());
+        assertEquals(true, domain.getEntities().get(0).getProperties().get(0).isRequired());
+    }
+
+    @Test
+    public void testParseXml_parsesEnum() {
+        Domain domain = DomainXMLParser.parseXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<enum name='TestEnum'>",
+                "</enum>",
+            "</domain>"
+        )));
+
+        assertEquals(1, domain.getEnums().size());
+        assertEquals("TestEnum", domain.getEnums().get(0).getName());
+        assertEquals(0, domain.getEnums().get(0).getValues().size());
+    }
+
+    @Test
+    public void testParseXml_parsesEnumValue() {
+        Domain domain = DomainXMLParser.parseXml(getStringStream(String.join("\n",
+            "<domain>",
+                "<enum name='TestEnum'>",
+                    "<value>A</value>",
+                "</enum>",
+            "</domain>"
+        )));
+
+        assertEquals(1, domain.getEnums().get(0).getValues().size());
+        assertEquals("A", domain.getEnums().get(0).getValues().get(0));
+    }
+
+    private InputStream getStringStream(String string) {
+        return new ByteArrayInputStream(string.getBytes());
+    }
+}


### PR DESCRIPTION
This is the module responsible for generating the builder-style recipe interfaces along with the backend hooks to plug in service logic, both in various languages. Right now I just have the parsing logic. A domain xml file contains all of the list of all of the entities in the "test domain" for which it will generate ingredients.