### PR TITLE
Add a postfix option for ingredient names

### DIFF
--- a/recipe-generator-java-testing/cookbook-postfix.yaml
+++ b/recipe-generator-java-testing/cookbook-postfix.yaml
@@ -1,0 +1,9 @@
+domain: "Postfix"
+ingredients:
+  - name: "PostfixIngredient"
+enums:
+  - name: "PostfixEnum"
+    values:
+      - "A"
+      - "B"
+      - "C"

--- a/recipe-generator-java-testing/pom.xml
+++ b/recipe-generator-java-testing/pom.xml
@@ -54,6 +54,17 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>generate-hooks</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <flavour>java-hook</flavour>
+                            <targetDir>${project.build.directory}/generated-test-sources/recipe</targetDir>
+                            <javaPackage>testdomain.hooks</javaPackage>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>generate-ingredients-domain-b</id>
                         <goals>
                             <goal>generate</goal>
@@ -65,14 +76,27 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>generate-hooks</id>
+                        <id>generate-ingredients-postfix</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <flavour>java-ingredient</flavour>
+                            <cookbook>${project.basedir}/cookbook-postfix.yaml</cookbook>
+                            <targetDir>${project.build.directory}/generated-test-sources/recipe</targetDir>
+                            <ingredientPostfix>Foo</ingredientPostfix>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-hooks-postfix</id>
                         <goals>
                             <goal>generate</goal>
                         </goals>
                         <configuration>
                             <flavour>java-hook</flavour>
+                            <cookbook>${project.basedir}/cookbook-postfix.yaml</cookbook>
                             <targetDir>${project.build.directory}/generated-test-sources/recipe</targetDir>
-                            <javaPackage>testdomain.hooks</javaPackage>
+                            <ingredientPostfix>Foo</ingredientPostfix>
                         </configuration>
                     </execution>
                 </executions>

--- a/recipe-generator-java-testing/src/test/java/JavaHookTest.java
+++ b/recipe-generator-java-testing/src/test/java/JavaHookTest.java
@@ -202,6 +202,12 @@ public class JavaHookTest {
     }
 
     @Test
+    public void testGeneration_doesNotAddIngredientPostfixToHook() {
+        new PostfixIngredientData();
+        Class c = AbstractPostfixIngredientHook.class;
+    }
+
+    @Test
     public void testBake_deserialization_emptyIngredient() {
         Runnable spy = spy(Runnable.class);
         BackendOven oven = new BackendOven();

--- a/recipe-generator-java-testing/src/test/java/JavaIngredientTest.java
+++ b/recipe-generator-java-testing/src/test/java/JavaIngredientTest.java
@@ -193,6 +193,17 @@ public class JavaIngredientTest {
     }
 
     @Test
+    public void testGeneration_ingredientWithPostfix() {
+        new PostfixIngredientFoo();
+    }
+
+    @Test
+    public void testGeneration_ingredientWithPostfixDoesNotIncludePostfixInType() {
+        PostfixIngredientFoo ingredient = new PostfixIngredientFoo();
+        assertEquals("PostfixIngredient", ingredient.getType());
+    }
+
+    @Test
     public void testBake_serialization_emptyIngredient() {
         setupDispatcherSpy();
         oven.bake(Recipe.prepare(new EmptyIngredient()));

--- a/recipe-generator-maven-plugin/src/main/java/ca/derekcormier/recipe/generator/RecipeGeneratorMojo.java
+++ b/recipe-generator-maven-plugin/src/main/java/ca/derekcormier/recipe/generator/RecipeGeneratorMojo.java
@@ -20,6 +20,8 @@ public class RecipeGeneratorMojo extends AbstractMojo {
     private String targetDir;
     @Parameter
     private String javaPackage;
+    @Parameter
+    private String ingredientPostfix;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -32,6 +34,11 @@ public class RecipeGeneratorMojo extends AbstractMojo {
         if (null != javaPackage) {
             args.add("--javaPackage");
             args.add(javaPackage);
+        }
+
+        if (null != ingredientPostfix) {
+            args.add("--ingredientPostfix");
+            args.add(ingredientPostfix);
         }
 
         Main.main(args.toArray(new String[args.size()]));

--- a/recipe-generator-ts-testing/pom.xml
+++ b/recipe-generator-ts-testing/pom.xml
@@ -70,6 +70,19 @@
                             <targetDir>${project.build.directory}/ingredients</targetDir>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>generate-ingredients-postfix</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <flavour>ts-ingredient</flavour>
+                            <cookbook>${project.basedir}/../recipe-generator-java-testing/cookbook-postfix.yaml</cookbook>
+                            <targetDir>${project.build.directory}/ingredients/postfix</targetDir>
+                            <ingredientPostfix>Foo</ingredientPostfix>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 

--- a/recipe-generator-ts-testing/src/IngredientTest.spec.ts
+++ b/recipe-generator-ts-testing/src/IngredientTest.spec.ts
@@ -5,6 +5,7 @@ import {
     AllParamsIngredient, IngredientWithCompoundOptional, IngredientWithRepeatableCompoundOptional,
     IngredientWithCompoundOptionalWithOneParam, IngredientWithDefaultRequiredNoInitializers
 } from "../target/ingredients";
+import { PostfixIngredientFoo } from "../target/ingredients/postfix";
 
 describe("generation", () => {
     it("should generate an empty ingredient", () => {
@@ -101,6 +102,15 @@ describe("generation", () => {
     it("should generate ingredients with the correct domain", () => {
         const ingredient = new AllParamsIngredient();
         expect(ingredient.getDomain()).to.equal("TestDomain");
+    });
+
+    it("should generate an ingredient with a postfix", () => {
+        new PostfixIngredientFoo();
+    });
+
+    it("should not include an ingredient postfix in the type", () => {
+        const ingredient = new PostfixIngredientFoo();
+        expect(ingredient.getType()).to.equal("PostfixIngredient");
     });
 });
 

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/JavaIngredientGenerator.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/JavaIngredientGenerator.java
@@ -18,6 +18,8 @@ public class JavaIngredientGenerator extends CookbookGenerator {
             options.put("javaPackage", "");
         }
 
+        options.putIfAbsent("ingredientPostfix", "");
+
         String javaPackage = (String)options.get("javaPackage");
         if (!javaPackage.isEmpty()) {
             targetDir += "/" + String.join("/", Arrays.asList(javaPackage.split("\\.")));
@@ -30,7 +32,7 @@ public class JavaIngredientGenerator extends CookbookGenerator {
             data.put("domain", cookbook.getDomain());
             data.put("options", options);
             String rendered = renderTemplate("templates/java/ingredient.liquid", data);
-            String filepath = directory + File.separator + ingredient.getName() + ".java";
+            String filepath = directory + File.separator + ingredient.getName() + options.get("ingredientPostfix") + ".java";
             writeToFile(filepath, rendered);
         }
 

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/Main.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/Main.java
@@ -23,6 +23,9 @@ public class Main {
     @Option(name = "--javaPackage", usage = "java package for generated classes", metaVar = "package")
     private String javaPackage;
 
+    @Option(name = "--ingredientPostfix", usage = "string to append to ingredient names", metaVar = "postfix")
+    private String ingredientPostfox;
+
     private CmdLineParser parser;
 
     public static void main(String[] args) {
@@ -62,6 +65,9 @@ public class Main {
         Map<String,Object> options = new HashMap<>();
         if (null != javaPackage) {
             options.put("javaPackage", javaPackage);
+        }
+        if (null != ingredientPostfox) {
+            options.put("ingredientPostfix", ingredientPostfox);
         }
         return options;
     }

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/TypescriptIngredientGenerator.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/TypescriptIngredientGenerator.java
@@ -24,6 +24,8 @@ public class TypescriptIngredientGenerator extends CookbookGenerator {
         registerFilters(cookbook);
         String directory = createDirectories(targetDir);
 
+        options.putIfAbsent("ingredientPostfix", "");
+
         // generate javascript ingredients
         for (Ingredient ingredient: cookbook.getIngredients()) {
             Map<String,Object> info = new HashMap<>();
@@ -36,7 +38,7 @@ public class TypescriptIngredientGenerator extends CookbookGenerator {
             data.put("options", options);
             data.put("info", info);
             String rendered = renderTemplate("templates/ts/ingredient.liquid", data);
-            String filepath = directory + File.separator + ingredient.getName() + ".js";
+            String filepath = directory + File.separator + ingredient.getName() + options.get("ingredientPostfix") + ".js";
             writeToFile(filepath, rendered);
         }
 
@@ -51,7 +53,7 @@ public class TypescriptIngredientGenerator extends CookbookGenerator {
             data.put("options", options);
             data.put("info", info);
             String rendered = renderTemplate("templates/ts/ingredient-types.liquid", data);
-            String filepath = directory + File.separator + ingredient.getName() + ".d.ts";
+            String filepath = directory + File.separator + ingredient.getName() + options.get("ingredientPostfix") + ".d.ts";
             writeToFile(filepath, rendered);
         }
 

--- a/recipe-generator/src/main/resources/templates/java/ingredient.liquid
+++ b/recipe-generator/src/main/resources/templates/java/ingredient.liquid
@@ -6,15 +6,16 @@
 {%- if options.javaPackage != "" -%}
 package {{options.javaPackage}};
 {% endif %}
+{%- assign ingredientName = ingredient.name | append:options.ingredientPostfix -%}
 
 import ca.derekcormier.recipe.{{superclass}};
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class {{ingredient.name}} extends {{superclass}} {
+public class {{ingredientName}} extends {{superclass}} {
     {%- for initializer in ingredient.initializers %}
-    public {{ingredient.name}}(
+    public {{ingredientName}}(
         {%- for param in initializer.params -%}
             {%- for required in ingredient.required -%}
                 {%- if param == required.name -%}
@@ -38,7 +39,7 @@ public class {{ingredient.name}} extends {{superclass}} {
     }{% endfor %}
 
     {% if ingredient.initializers.size == 0 %}
-    public {{ingredient.name}}() {
+    public {{ingredientName}}() {
         super("{{ingredient.name}}", "{{domain}}");
     {%- for required in ingredient.required %}
         setRequired("{{required.name}}", {{required.default | javavalue:required.type}});
@@ -46,7 +47,7 @@ public class {{ingredient.name}} extends {{superclass}} {
     }{% endif %}
 
     {%- for optional in ingredient.optionals %}
-    public {{ingredient.name}} with{{optional.name | capitalize}}(
+    public {{ingredientName}} with{{optional.name | capitalize}}(
         {%- if optional.compound != true -%}
             {%- if optional.type != 'flag' -%}
             {{optional.type | javatype}} {{optional.name}}

--- a/recipe-generator/src/main/resources/templates/ts/ingredient-index-types.liquid
+++ b/recipe-generator/src/main/resources/templates/ts/ingredient-index-types.liquid
@@ -1,5 +1,6 @@
 {% for ingredient in ingredients %}
-export { {{ingredient.name}} } from "./{{ingredient.name}}"
+{%- assign ingredientName = ingredient.name | append:options.ingredientPostfix -%}
+export { {{ingredientName}} } from "./{{ingredientName}}"
 {% endfor %}
 {% for enum in enums %}
 export { {{enum.name}} } from "./{{enum.name}}"

--- a/recipe-generator/src/main/resources/templates/ts/ingredient-index.liquid
+++ b/recipe-generator/src/main/resources/templates/ts/ingredient-index.liquid
@@ -2,8 +2,9 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 
 {% for ingredient in ingredients %}
-var {{ingredient.name}}_ = require("./{{ingredient.name}}");
-exports.{{ingredient.name}} = {{ingredient.name}}_.{{ingredient.name}};
+{%- assign ingredientName = ingredient.name | append:options.ingredientPostfix -%}
+var {{ingredientName}}_ = require("./{{ingredientName}}");
+exports.{{ingredientName}} = {{ingredientName}}_.{{ingredientName}};
 {% endfor %}
 {% for enum in enums %}
 var {{enum.name}}_ = require("./{{enum.name}}");

--- a/recipe-generator/src/main/resources/templates/ts/ingredient-types.liquid
+++ b/recipe-generator/src/main/resources/templates/ts/ingredient-types.liquid
@@ -3,12 +3,13 @@
 {%- else -%}
     {%- assign superclass = 'Ingredient' -%}
 {%- endif -%}
+{%- assign ingredientName = ingredient.name | append:options.ingredientPostfix -%}
 import { {{ superclass}} } from "recipe-ts-runtime";
 {% for type in info.nonPrimitiveTypes -%}
 import { {{ type }} } from "./{{type}}";
 {% endfor %}
 
-export class {{ingredient.name}} extends {{superclass}} {
+export class {{ingredientName}} extends {{superclass}} {
     {%- for initializer in ingredient.initializers %}
     constructor(
         {%- for param in initializer.params -%}
@@ -39,6 +40,6 @@ export class {{ingredient.name}} extends {{superclass}} {
                 {%- unless forloop.last -%}, {% endunless -%}
             {%- endfor -%}
         {%- endif -%}
-    ): {{ingredient.name}};
+    ): {{ingredientName}};
     {% endfor %}
 }

--- a/recipe-generator/src/main/resources/templates/ts/ingredient.liquid
+++ b/recipe-generator/src/main/resources/templates/ts/ingredient.liquid
@@ -5,12 +5,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 {%- else -%}
     {%- assign superclass = 'Ingredient' -%}
 {%- endif -%}
+{%- assign ingredientName = ingredient.name | append:options.ingredientPostfix -%}
 const {{superclass}} = require("recipe-ts-runtime").{{superclass}};
 {% for type in info.nonPrimitiveTypes -%}
 const {{type}} = require("./{{type}}").{{type}};
 {% endfor %}
 
-class {{ingredient.name}} extends {{superclass}} {
+class {{ingredientName}} extends {{superclass}} {
     constructor(...args) {
         super("{{ingredient.name}}", "{{domain}}");
         {% for initializer in ingredient.initializers %}
@@ -73,4 +74,4 @@ class {{ingredient.name}} extends {{superclass}} {
     {% endfor %}
 }
 
-exports.{{ingredient.name}} = {{ingredient.name}};
+exports.{{ingredientName}} = {{ingredientName}};


### PR DESCRIPTION
@jbedard 

This is so that we can call ingredients "Column", "Budget", etc. in the cookbook and still have the ingredients called "ColumnSetup", "BudgetSetup", ...

Could be useful for avoiding annoying name conflicts with domain objects, though those probably shouldn't be in the test files anyway.