### PR TITLE
Support null string values in typescript

### DIFF
--- a/recipe-generator-java-testing/cookbook.yaml
+++ b/recipe-generator-java-testing/cookbook.yaml
@@ -35,6 +35,12 @@ ingredients:
         type: "int"
         default: 5
 
+  - name: "IngredientWithNullStringDefault"
+    required:
+      - name: "required"
+        type: "string"
+        default: null
+
   - name: "IngredientWithOptional"
     optionals:
       - name: "optional"

--- a/recipe-generator-java-testing/src/test/java/JavaHookTest.java
+++ b/recipe-generator-java-testing/src/test/java/JavaHookTest.java
@@ -16,6 +16,7 @@ import testdomain.hooks.AbstractEmptyIngredientHook;
 import testdomain.hooks.AbstractIngredientWithCompoundOptionalHook;
 import testdomain.hooks.AbstractIngredientWithDefaultRequiredNoInitializersHook;
 import testdomain.hooks.AbstractIngredientWithKeyConstantHook;
+import testdomain.hooks.AbstractIngredientWithNullStringDefaultHook;
 import testdomain.hooks.AbstractIngredientWithOptionalHook;
 import testdomain.hooks.AbstractIngredientWithRepeatableCompoundOptionalHook;
 import testdomain.hooks.AbstractIngredientWithRepeatableOptionalHook;
@@ -29,6 +30,7 @@ import testdomain.hooks.EmptyIngredientData;
 import testdomain.hooks.IngredientWithCompoundOptionalData;
 import testdomain.hooks.IngredientWithDefaultRequiredNoInitializersData;
 import testdomain.hooks.IngredientWithKeyConstantData;
+import testdomain.hooks.IngredientWithNullStringDefaultData;
 import testdomain.hooks.IngredientWithOptionalData;
 import testdomain.hooks.IngredientWithRepeatableCompoundOptionalData;
 import testdomain.hooks.IngredientWithRepeatableOptionalData;
@@ -261,6 +263,22 @@ public class JavaHookTest {
         });
 
         oven.bake(payloadJson("{\"IngredientWithDefaultRequiredNoInitializers\":{\"required\":5}}"));
+        verify(spy).run();
+    }
+
+    @Test
+    public void testBake_deserialization_ingredientWithNullDefaultString() {
+        Runnable spy = spy(Runnable.class);
+        BackendOven oven = new BackendOven();
+        oven.registerHook(new AbstractIngredientWithNullStringDefaultHook() {
+            @Override
+            public void bake(IngredientWithNullStringDefaultData data, Cake cake) {
+                assertEquals(null, data.getRequired());
+                spy.run();
+            }
+        });
+
+        oven.bake(payloadJson("{\"IngredientWithNullStringDefault\":{\"required\":null}}"));
         verify(spy).run();
     }
 

--- a/recipe-generator-java-testing/src/test/java/JavaIngredientTest.java
+++ b/recipe-generator-java-testing/src/test/java/JavaIngredientTest.java
@@ -30,6 +30,7 @@ import testdomain.ingredients.IngredientWithCompoundOptionalWithOneParam;
 import testdomain.ingredients.IngredientWithDefaultRequired;
 import testdomain.ingredients.IngredientWithDefaultRequiredNoInitializers;
 import testdomain.ingredients.IngredientWithKeyConstant;
+import testdomain.ingredients.IngredientWithNullStringDefault;
 import testdomain.ingredients.IngredientWithOptional;
 import testdomain.ingredients.IngredientWithRepeatableCompoundOptional;
 import testdomain.ingredients.IngredientWithRepeatableOptional;
@@ -70,6 +71,11 @@ public class JavaIngredientTest {
     @Test
     public void testGeneration_ingredientWithDefaultRequiredNoInitializers() {
         new IngredientWithDefaultRequiredNoInitializers();
+    }
+
+    @Test
+    public void testGeneration_ingredientWithNullStringDefault() {
+        new IngredientWithNullStringDefault();
     }
 
     @Test
@@ -245,6 +251,14 @@ public class JavaIngredientTest {
         oven.bake(Recipe.prepare(new IngredientWithDefaultRequired(false)));
 
         assertDispatchedJson(payloadJson("{\"IngredientWithDefaultRequired\":{\"param1\":\"foobar\",\"param2\":false,\"param3\":\"A\"}}"));
+    }
+
+    @Test
+    public void testBake_serialization_ingredientWithNullStringDefault() {
+        setupDispatcherSpy("TestDomain");
+        oven.bake(Recipe.prepare(new IngredientWithNullStringDefault()));
+
+        assertDispatchedJson(payloadJson("{\"IngredientWithNullStringDefault\":{\"required\":null}}"));
     }
 
     @Test

--- a/recipe-generator-ts-testing/src/IngredientTest.spec.ts
+++ b/recipe-generator-ts-testing/src/IngredientTest.spec.ts
@@ -4,7 +4,7 @@ import {
     IngredientWithRepeatableOptional, IngredientWithRepeatableVarargOptional, IngredientWithRequiredAndOptional,
     AllParamsIngredient, IngredientWithCompoundOptional, IngredientWithRepeatableCompoundOptional,
     IngredientWithCompoundOptionalWithOneParam, IngredientWithDefaultRequiredNoInitializers,
-    IngredientWithStringDefaultContainingQuotes, IngredientWithKeyConstant
+    IngredientWithStringDefaultContainingQuotes, IngredientWithKeyConstant, IngredientWithNullStringDefault
 } from "../target/ingredients";
 import { PostfixIngredientFoo } from "../target/ingredients/postfix";
 
@@ -21,6 +21,10 @@ describe("generation", () => {
         new IngredientWithDefaultRequired("foo");
         new IngredientWithDefaultRequired(false);
         new IngredientWithDefaultRequired(TestEnum.B);
+    });
+
+    it("should generate an ingredient with a null string default param", () => {
+        new IngredientWithNullStringDefault();
     });
 
     it("should generate an ingredient with a required param with a default but no initializers", () => {
@@ -127,6 +131,15 @@ describe("generation", () => {
     it("should generate key constants", () => {
         expect(IngredientWithKeyConstant.KEY_A).to.equal("KEY_A");
     });
+
+    it("should allow string params to take null", () => {
+        new IngredientWithRequired(null);
+        new AllParamsIngredient().withStringArg(null);
+    });
+
+    it("should allow string array params to take null", () => {
+        new AllParamsIngredient().withStringArrayArg([null, "foo", null]);
+    });
 });
 
 describe("serialization", () => {
@@ -144,6 +157,10 @@ describe("serialization", () => {
 
     it("should serialize an ingredient with a required param with a default but no initializers", () => {
         expectJsonEquals(`{"IngredientWithDefaultRequiredNoInitializers":{"required":5}}`, new IngredientWithDefaultRequiredNoInitializers());
+    });
+
+    it("should serialize an ingredient with a null string default param", () => {
+        expectJsonEquals(`{"IngredientWithNullStringDefault":{"required":null}}`, new IngredientWithNullStringDefault());
     });
 
     it("should serialize an ingredient with an optional param", () => {
@@ -192,6 +209,14 @@ describe("serialization", () => {
 
     it("should serialize an ingredient with a string default containing quotes", () => {
         expectJsonEquals(`{"IngredientWithStringDefaultContainingQuotes":{"required":"\\"foo"}}`, new IngredientWithStringDefaultContainingQuotes());
+    });
+
+    it("should serialize an ingredient with a null string value", () => {
+        expectJsonEquals(`{"AllParamsIngredient":{"stringArg":null}}`, new AllParamsIngredient().withStringArg(null));
+    });
+
+    it("should serialize an ingredient with an array of string values with nulls", () => {
+        expectJsonEquals(`{"AllParamsIngredient":{"stringArrayArg":["foo", null, "bar"]}}`, new AllParamsIngredient().withStringArrayArg(["foo", null, "bar"]));
     });
 });
 

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/CookbookGenerator.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/CookbookGenerator.java
@@ -24,7 +24,7 @@ public abstract class CookbookGenerator {
         InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(templatePath);
         Scanner scanner = new Scanner(inputStream).useDelimiter("\\A");
         String templateContent = scanner.hasNext() ? scanner.next() : "";
-        Template template = Template.parse(templateContent).withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build());
+        Template template = Template.parse(templateContent).withRenderSettings(new RenderSettings.Builder().withStrictVariables(false).build());
         try {
             return template.render(objectMapper.writeValueAsString(data));
         }

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/JavaFilters.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/JavaFilters.java
@@ -79,7 +79,7 @@ public class JavaFilters {
                             case FLOAT:
                                 return super.asString(value);
                             case STRING:
-                                return "\"" + super.asString(value).replace("\"", "\\\"") + "\"";
+                                return value == null ? "null" : "\"" + super.asString(value).replace("\"", "\\\"") + "\"";
                             default:
                                 throw new RuntimeException("unknown data type '" + strType + "'");
                         }

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/TypescriptFilters.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/TypescriptFilters.java
@@ -67,7 +67,7 @@ public class TypescriptFilters {
                             case FLOAT:
                                 return super.asString(value);
                             case STRING:
-                                return "\"" + super.asString(value).replace("\"", "\\\"") + "\"";
+                                return value == null ? "null" : "\"" + super.asString(value).replace("\"", "\\\"") + "\"";
                             default:
                                 throw new RuntimeException("unknown data type '" + strType + "'");
                         }
@@ -87,7 +87,8 @@ public class TypescriptFilters {
     }
 
     private static String toTsType(ParamType type) {
-        return _toTsType(type.getType()) + (type.isVararg() ? "[]" : "");
+        boolean isWrapped = type.isVararg() && type.getType() instanceof PrimitiveType && ((PrimitiveType)type.getType()).getPrimitive() == Primitive.STRING;
+        return (isWrapped ? "(" : "") + _toTsType(type.getType()) + (isWrapped ? ")" : "") + (type.isVararg() ? "[]" : "");
     }
 
     private static String _toTsType(Type type) {
@@ -100,7 +101,7 @@ public class TypescriptFilters {
                 case FLOAT:
                     return "number";
                 case STRING:
-                    return "string";
+                    return "string | null";
                 default:
                     throw new RuntimeException("unknown type");
             }
@@ -112,7 +113,8 @@ public class TypescriptFilters {
             return ((EnumType)type).getName();
         }
         else if (type instanceof ArrayType) {
-            return _toTsType(((ArrayType)type).getBaseType()) + "[]";
+            boolean isWrapped = ((ArrayType)type).getBaseType() instanceof PrimitiveType && ((PrimitiveType)((ArrayType)type).getBaseType()).getPrimitive() == Primitive.STRING;
+            return (isWrapped ? "(" : "") + _toTsType(((ArrayType)type).getBaseType()) + (isWrapped ? ")" : "") + "[]";
         }
         throw new RuntimeException("unknown type");
     }

--- a/recipe-generator/src/main/resources/templates/ts/ingredient.liquid
+++ b/recipe-generator/src/main/resources/templates/ts/ingredient.liquid
@@ -19,7 +19,9 @@ class {{ingredientName}} extends {{superclass}} {
         {%- for param in initializer.params -%}
             {%- assign type = info.requiredTypes[param] -%}
             {% raw %} {% endraw %}
-            {%- if type == 'string' or type == 'int' or type == 'float' or type == 'boolean' -%}
+            {%- if type == 'string' -%}
+                && (args[{{forloop.index0}}] === null || typeof args[{{forloop.index0}}] === "string")
+            {%- elsif type == 'int' or type == 'float' or type == 'boolean' -%}
                 && typeof args[{{forloop.index0}}] === "{{type | tstype}}"
             {%- else -%}
                 && (args[{{forloop.index0}}] instanceof {{type}})


### PR DESCRIPTION
@jbedard 

Do you remember how we discussed that we wouldn't allow required parameters (those in the constructor) to be null, because then in a javascript constructor we can't deduce which signature the constructor was called with because of type erasure?

Well it dawned on me that, since I don't support object parameters (and don't plan to), only primitives, enums, and arrays, then we can allow string types in typescript to be `string | null` because only strings can be null. This is consistent in the java ingredients: none of the primitives can be null, but strings can be. Maybe enums could be as well in Java, and if so I'll probably add runtime validation against that.

In the process of doing this I also discovered a couple bugs java-side when defaulting a string param to null.

This PR basically sets all `: string` ts types to be `: string | null`, wrapping it in parentheses in the case of vararg arguments or array arguments: `(string | null)[]`.
  