### PR TITLE
Return defaults for optionals when they are missing

### DIFF
--- a/recipe-generator-java-testing/src/test/java/JavaHookTest.java
+++ b/recipe-generator-java-testing/src/test/java/JavaHookTest.java
@@ -218,6 +218,56 @@ public class JavaHookTest {
     }
 
     @Test
+    public void testGeneration_missingIntOptionalDefault() {
+        assertEquals(0, new AllParamsIngredientData().getIntArg());
+    }
+
+    @Test
+    public void testGeneration_missingFloatOptionalDefault() {
+        assertEquals(0.0f, new AllParamsIngredientData().getFloatArg(), 0.0);
+    }
+
+    @Test
+    public void testGeneration_missingBooleanOptionalDefault() {
+        assertEquals(false, new AllParamsIngredientData().isBooleanArg());
+    }
+
+    @Test
+    public void testGeneration_missingFlagOptionalDefault() {
+        assertEquals(false, new AllParamsIngredientData().isFlagArg());
+    }
+
+    @Test
+    public void testGeneration_missingStringOptionalDefault() {
+        assertEquals(null, new AllParamsIngredientData().getStringArg());
+    }
+
+    @Test
+    public void testGeneration_missingArrayOptionalDefault() {
+        assertArrayEquals(new String[0], new AllParamsIngredientData().getStringArrayArg());
+    }
+
+    @Test
+    public void testGeneration_missingEnumOptionalDefault() {
+        assertEquals(TestEnum.A, new AllParamsIngredientData().getEnumArg());
+    }
+
+    @Test
+    public void testGeneration_missingCompoundOptionalObjectDefault() {
+        assertEquals(null, new IngredientWithCompoundOptionalData().getCompoundOptional());
+    }
+
+    @Test
+    public void testGeneration_missingRepeatableOptionalDefault() {
+        assertArrayEquals(new boolean[0], new IngredientWithRepeatableOptionalData().isOptional());
+    }
+
+    @Test
+    public void testGeneration_missingRepeatableCompoundOptionalObjectDefault() {
+        assertArrayEquals(new IngredientWithRepeatableCompoundOptionalData.CompoundOptionalParams[0], new IngredientWithRepeatableCompoundOptionalData().getCompoundOptional());
+    }
+
+    @Test
     public void testBake_deserialization_emptyIngredient() {
         Runnable spy = spy(Runnable.class);
         BackendOven oven = new BackendOven();

--- a/recipe-generator/src/main/resources/templates/java/ingredient-data.liquid
+++ b/recipe-generator/src/main/resources/templates/java/ingredient-data.liquid
@@ -28,14 +28,14 @@ public class {{dataClassName}} extends {{superclass}} {
     }
         {%- if optional.compound != true %}
     public {{optional.type | javatype:true}}{% if optional.repeatable == true %}[]{% endif %} {% if optional.type != 'boolean' and optional.type != 'flag' %}get{% else %}is{% endif %}{{optional.name | capitalize}}() {
-        return getProperty("{{optional.name}}");
+        return getProperty({{optional.type | javatype:true}}{% if optional.repeatable == true %}[]{% endif %}.class, "{{optional.name}}");
     }
     private void set{{optional.name | capitalize}}({{optional.type | javatype:true}}{% if optional.repeatable == true %}[]{% endif %} {{optional.name}}) {
         setProperty("{{optional.name}}", {{optional.name}});
     }
         {%- else -%}
     public {{optional.name | capitalize}}Params{% if optional.repeatable == true %}[]{% endif %} get{{optional.name | capitalize}}() {
-        return getProperty("{{optional.name}}");
+        return getProperty({{optional.name | capitalize}}Params{% if optional.repeatable == true %}[]{% endif %}.class, "{{optional.name}}");
     }
     private void set{{optional.name | capitalize}}({{optional.name | capitalize}}Params{% if optional.repeatable == true %}[]{% endif %} {{optional.name}}) {
         setProperty("{{optional.name}}", {{optional.name}});

--- a/recipe-java-runtime/src/main/java/ca/derekcormier/recipe/BaseIngredient.java
+++ b/recipe-java-runtime/src/main/java/ca/derekcormier/recipe/BaseIngredient.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.lang.reflect.Array;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,6 +45,32 @@ public abstract class BaseIngredient {
 
     protected <T> T getProperty(String key) {
         return (T)properties.get(key);
+    }
+
+    protected <T> T getProperty(Class<T> clazz, String key) {
+        if (hasProperty(key)) {
+            return (T)getProperty(key);
+        }
+        else if (clazz == int.class) {
+            return (T)new Integer(0);
+        }
+        else if (clazz == float.class) {
+            return (T)new Float(0.0f);
+        }
+        else if (clazz == boolean.class) {
+            return (T)new Boolean(false);
+        }
+        else if (clazz == String.class) {
+            return null;
+        }
+        else if (clazz.isEnum()) {
+            return clazz.getEnumConstants()[0];
+        }
+        else if (clazz.isArray()) {
+            return (T)Array.newInstance(clazz.getComponentType(), 0);
+        }
+
+        return null;
     }
 
     protected boolean hasProperty(String key) {

--- a/recipe-java-runtime/src/main/java/ca/derekcormier/recipe/KeyedIngredientSnapshot.java
+++ b/recipe-java-runtime/src/main/java/ca/derekcormier/recipe/KeyedIngredientSnapshot.java
@@ -17,4 +17,8 @@ public abstract class KeyedIngredientSnapshot extends IngredientSnapshot {
     public String getKey() {
         return key;
     }
+
+    public boolean hasKey() {
+        return key != null;
+    }
 }

--- a/recipe-java-runtime/src/test/java/ca/derekcormier/recipe/BaseIngredientTest.java
+++ b/recipe-java-runtime/src/test/java/ca/derekcormier/recipe/BaseIngredientTest.java
@@ -1,7 +1,9 @@
 package ca.derekcormier.recipe;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -25,5 +27,83 @@ public class BaseIngredientTest {
     public void testHasProperty_propertyDoesNotExist() {
         BaseIngredient ingredient = new BaseIngredient("TestIngredient", "A") {};
         assertFalse(ingredient.hasProperty("foo"));
+    }
+
+    @Test
+    public void testGetProperty_getsExistingValue() {
+        BaseIngredient ingredient = new BaseIngredient("TestIngredient", "A") {};
+        ingredient.setProperty("foo", TestEnum.B);
+        TestEnum value = ingredient.getProperty("foo");
+        assertEquals(TestEnum.B, value);
+    }
+
+    @Test
+    public void testGetProperty_returnsNullOnNonExistentKey() {
+        BaseIngredient ingredient = new BaseIngredient("TestIngredient", "A") {};
+        assertNull(ingredient.getProperty("foo"));
+    }
+
+    @Test
+    public void testGetProperty_withType_getsExistingValue() {
+        BaseIngredient ingredient = new BaseIngredient("TestIngredient", "A") {};
+        ingredient.setProperty("foo", 7);
+        int value = ingredient.getProperty(int.class, "foo");
+        assertEquals(7, value);
+    }
+
+    @Test
+    public void testGetProperty_withType_intDefaultsTo0() {
+        BaseIngredient ingredient = new BaseIngredient("TestIngredient", "A") {};
+        int value = ingredient.getProperty(int.class, "foo");
+        assertEquals(0, value);
+    }
+
+    @Test
+    public void testGetProperty_withType_floatDefaultsTo0() {
+        BaseIngredient ingredient = new BaseIngredient("TestIngredient", "A") {};
+        float value = ingredient.getProperty(float.class, "foo");
+        assertEquals(0.0f, value, 0.0);
+    }
+
+    @Test
+    public void testGetProperty_withType_booleanDefaultsToFalse() {
+        BaseIngredient ingredient = new BaseIngredient("TestIngredient", "A") {};
+        boolean value = ingredient.getProperty(boolean.class, "foo");
+        assertEquals(false, value);
+    }
+
+    @Test
+    public void testGetProperty_withType_stringDefaultsToNull() {
+        BaseIngredient ingredient = new BaseIngredient("TestIngredient", "A") {};
+        String value = ingredient.getProperty(String.class, "foo");
+        assertEquals(null, value);
+    }
+
+    @Test
+    public void testGetProperty_withType_enumDefaultsToFirstDeclaredValue() {
+        BaseIngredient ingredient = new BaseIngredient("TestIngredient", "A") {};
+        TestEnum value = ingredient.getProperty(TestEnum.class, "foo");
+        assertEquals(TestEnum.A, value);
+    }
+
+    @Test
+    public void testGetProperty_withType_arrayDefaultsToEmptyArray() {
+        BaseIngredient ingredient = new BaseIngredient("TestIngredient", "A") {};
+        String[] value = ingredient.getProperty(String[].class, "foo");
+        assertArrayEquals(new String[0], value);
+    }
+
+    @Test
+    public void testGetProperty_withType_objectDefaultsToNull() {
+        BaseIngredient ingredient = new BaseIngredient("TestIngredient", "A") {};
+        SomeClass value = ingredient.getProperty(SomeClass.class, "foo");
+        assertEquals(null, value);
+    }
+
+    public enum TestEnum {
+        A, B, C
+    }
+
+    public class SomeClass {
     }
 }


### PR DESCRIPTION
@jbedard 

Previously in a hook, if you want to safely get a value for an optional parameter you have to do:
```
if (ingredient.hasX() && ingredient.getX() == 5) {
    ....
}
```
If you just called `ingredient.getX()` and the optional wasn't specified in the ingredient, it would throw an error. Now, optionals that are missing just get default values (zeros, null, empty array, etc) so that the logic can be simplified in some cases, but you can still check if the optional was specified with `hasX()`, if that's important to the use-case.

For example, this is especially cleaner for boolean parameters so you can just write:
```
if (ingredient.getX()) {
    ....
}
```