### PR TITLE
Sanitize language-specific keywords used as identifiers

### DIFF
--- a/recipe-generator-java-testing/cookbook.yaml
+++ b/recipe-generator-java-testing/cookbook.yaml
@@ -184,6 +184,42 @@ ingredients:
       - params: ["requiredEnum"]
       - params: ["requiredString"]
 
+  - name: "IngredientWithJavaKeywords"
+    required:
+      - name: "synchronized"
+        type: "boolean"
+    initializers:
+      - params: ["synchronized"]
+    optionals:
+      - name: "class"
+        type: "int"
+      - name: "boolean"
+        type: "boolean"
+      - name: "package"
+        params:
+          - name: "super"
+            type: "int"
+          - name: "break"
+            type: "string"
+
+  - name: "IngredientWithTypeScriptKeywords"
+    required:
+    - name: "any"
+      type: "boolean"
+    initializers:
+    - params: ["any"]
+    optionals:
+    - name: "const"
+      type: "int"
+    - name: "number"
+      type: "boolean"
+    - name: "delete"
+      params:
+      - name: "enum"
+        type: "int"
+      - name: "false"
+        type: "string"
+
 enums:
   - name: "TestEnum"
     values:

--- a/recipe-generator-java-testing/src/test/java/JavaHookTest.java
+++ b/recipe-generator-java-testing/src/test/java/JavaHookTest.java
@@ -16,6 +16,7 @@ import testdomain.hooks.AbstractEmptyIngredientHook;
 import testdomain.hooks.AbstractIngredientWithCompoundOptionalHook;
 import testdomain.hooks.AbstractIngredientWithConstantHook;
 import testdomain.hooks.AbstractIngredientWithDefaultRequiredNoInitializersHook;
+import testdomain.hooks.AbstractIngredientWithJavaKeywordsHook;
 import testdomain.hooks.AbstractIngredientWithNullStringDefaultHook;
 import testdomain.hooks.AbstractIngredientWithOptionalHook;
 import testdomain.hooks.AbstractIngredientWithRepeatableCompoundOptionalHook;
@@ -29,6 +30,7 @@ import testdomain.hooks.AllParamsIngredientData;
 import testdomain.hooks.EmptyIngredientData;
 import testdomain.hooks.IngredientWithCompoundOptionalData;
 import testdomain.hooks.IngredientWithDefaultRequiredNoInitializersData;
+import testdomain.hooks.IngredientWithJavaKeywordsData;
 import testdomain.hooks.IngredientWithNullStringDefaultData;
 import testdomain.hooks.IngredientWithOptionalData;
 import testdomain.hooks.IngredientWithRepeatableCompoundOptionalData;
@@ -204,6 +206,15 @@ public class JavaHookTest {
         new AllParamsIngredientData();
         AllParamsIngredientData.class.getMethod("getVarargArrayArg");
         assertEquals(int[][].class, AllParamsIngredientData.class.getMethod("getVarargArrayArg").getReturnType());
+    }
+
+    @Test
+    public void testGeneration_ingredientWithJavaKeywords() throws NoSuchMethodException {
+        new IngredientWithJavaKeywordsData();
+        IngredientWithJavaKeywordsData.class.getMethod("isSynchronized");
+        IngredientWithJavaKeywordsData.class.getMethod("getClass_");
+        IngredientWithJavaKeywordsData.class.getMethod("isBoolean");
+        IngredientWithJavaKeywordsData.class.getMethod("getPackage");
     }
 
     @Test
@@ -724,6 +735,27 @@ public class JavaHookTest {
         });
 
         oven.bake(payloadJson("{\"IngredientWithStringDefaultContainingQuotes\":{\"required\":\"\\\"foo\"}}"));
+        verify(spy).run();
+    }
+
+    @Test
+    public void testBake_deserialization_ingredientWithJavaKeywords() {
+        Runnable spy = spy(Runnable.class);
+        BackendOven oven = new BackendOven();
+        oven.registerHook(new AbstractIngredientWithJavaKeywordsHook() {
+            @Override
+            public void bake(IngredientWithJavaKeywordsData data, Cake cake) {
+                assertEquals(true, data.isSynchronized());
+                assertEquals(false, data.isBoolean());
+                assertEquals(4, data.getClass_());
+                assertEquals(2, data.getPackage()._super);
+                assertEquals("foobar", data.getPackage()._break);
+
+                spy.run();
+            }
+        });
+
+        oven.bake(payloadJson("{\"IngredientWithJavaKeywords\":{\"synchronized\":true,\"boolean\":false,\"class\":4,\"package\":{\"super\":2,\"break\":\"foobar\"}}}"));
         verify(spy).run();
     }
 

--- a/recipe-generator-java-testing/src/test/java/JavaIngredientTest.java
+++ b/recipe-generator-java-testing/src/test/java/JavaIngredientTest.java
@@ -30,6 +30,7 @@ import testdomain.ingredients.IngredientWithCompoundOptionalWithOneParam;
 import testdomain.ingredients.IngredientWithDefaultRequired;
 import testdomain.ingredients.IngredientWithDefaultRequiredNoInitializers;
 import testdomain.ingredients.IngredientWithConstant;
+import testdomain.ingredients.IngredientWithJavaKeywords;
 import testdomain.ingredients.IngredientWithNullStringDefault;
 import testdomain.ingredients.IngredientWithOptional;
 import testdomain.ingredients.IngredientWithRepeatableCompoundOptional;
@@ -225,6 +226,14 @@ public class JavaIngredientTest {
     @Test
     public void testGeneration_ingredientWithRequiredVarargStringArrayWithDefault() {
         new IngredientWithRequiredVarargStringArrayWithDefault();
+    }
+
+    @Test
+    public void testGeneration_ingredientWithJavaKeywords() {
+        new IngredientWithJavaKeywords(true)
+            .withBoolean(false)
+            .withClass(5)
+            .withPackage(2, "foo");
     }
 
     @Test
@@ -439,6 +448,20 @@ public class JavaIngredientTest {
 
         assertDispatchedJson(payloadJson(
             "{\"IngredientWithRequiredVarargStringArrayWithDefault\":{\"required\":[[\"foo\",\"bar\"],[\"moo\"]]}}"
+        ));
+    }
+
+    @Test
+    public void testBake_serialization_ingredientWithJavaKeywords() {
+        setupDispatcherSpy("TestDomain");
+        oven.bake(Recipe.prepare(
+            new IngredientWithJavaKeywords(true)
+                .withBoolean(false)
+                .withClass(4)
+                .withPackage(2, "foobar")
+        ));
+        assertDispatchedJson(payloadJson(
+            "{\"IngredientWithJavaKeywords\":{\"synchronized\":true,\"boolean\":false,\"class\":4,\"package\":{\"super\":2,\"break\":\"foobar\"}}}"
         ));
     }
 

--- a/recipe-generator-ts-testing/src/IngredientTest.spec.ts
+++ b/recipe-generator-ts-testing/src/IngredientTest.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { EmptyIngredient, IngredientWithOptional, IngredientWithDefaultRequired, IngredientWithRequired, TestEnum, IngredientWithRepeatableOptional, IngredientWithRepeatableVarargOptional, IngredientWithRequiredAndOptional, AllParamsIngredient, IngredientWithCompoundOptional, IngredientWithRepeatableCompoundOptional, IngredientWithCompoundOptionalWithOneParam, IngredientWithDefaultRequiredNoInitializers, IngredientWithMultipleInitializersWithEnumAndStringInSamePosition, IngredientWithStringDefaultContainingQuotes, IngredientWithNullStringDefault, IngredientWithConstant, KeyedIngredientWithDefaultKey, KeyedIngredientWithDefaultKeyParamIsDefaulted, IngredientWithRequiredVararg, IngredientWithRequiredStringArrayWithDefault, IngredientWithRequiredVarargStringArrayWithDefault, IngredientWithRequiredAndRequiredVararg } from "../target/ingredients";
+import { EmptyIngredient, IngredientWithOptional, IngredientWithDefaultRequired, IngredientWithRequired, TestEnum, IngredientWithRepeatableOptional, IngredientWithRepeatableVarargOptional, IngredientWithRequiredAndOptional, AllParamsIngredient, IngredientWithCompoundOptional, IngredientWithRepeatableCompoundOptional, IngredientWithCompoundOptionalWithOneParam, IngredientWithDefaultRequiredNoInitializers, IngredientWithMultipleInitializersWithEnumAndStringInSamePosition, IngredientWithStringDefaultContainingQuotes, IngredientWithNullStringDefault, IngredientWithConstant, KeyedIngredientWithDefaultKey, KeyedIngredientWithDefaultKeyParamIsDefaulted, IngredientWithRequiredVararg, IngredientWithRequiredStringArrayWithDefault, IngredientWithRequiredVarargStringArrayWithDefault, IngredientWithRequiredAndRequiredVararg, IngredientWithTypeScriptKeywords } from "../target/ingredients";
 import { PostfixIngredientFoo } from "../target/ingredients/postfix";
 
 describe("generation", () => {
@@ -112,6 +112,13 @@ describe("generation", () => {
 
     it("should generate and ingredient with a string default containing quotes", () => {
         new IngredientWithStringDefaultContainingQuotes();
+    });
+
+    it("should generate and ingredient with typescript keywords", () => {
+        new IngredientWithTypeScriptKeywords(true)
+            .withConst(5)
+            .withNumber(true)
+            .withDelete(5, "foobar");
     });
 
     it("should generate ingredients with the correct domain", () => {
@@ -234,6 +241,10 @@ describe("serialization", () => {
 
     it("should serialize an ingredient with an array of string values with nulls", () => {
         expectJsonEquals(`{"AllParamsIngredient":{"stringArrayArg":["foo", null, "bar"]}}`, new AllParamsIngredient().withStringArrayArg(["foo", null, "bar"]));
+    });
+
+    it("should serialize an ingredient with typescript keywords", () => {
+        expectJsonEquals(`{"IngredientWithTypeScriptKeywords":{"any":true,"const":4,"number":false,"delete":{"enum":5,"false":"foobar"}}}`, new IngredientWithTypeScriptKeywords(true).withConst(4).withNumber(false).withDelete(5, "foobar"));
     });
 
     it("should serialize a keyed ingredient with a default key", () => {

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/JavaCookbookGenerator.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/JavaCookbookGenerator.java
@@ -1,6 +1,8 @@
 package ca.derekcormier.recipe.generator;
 
 import ca.derekcormier.recipe.cookbook.Cookbook;
+import ca.derekcormier.recipe.generator.filter.JavaGetterFilter;
+import ca.derekcormier.recipe.generator.filter.JavaIdentifierFilter;
 import ca.derekcormier.recipe.generator.filter.JavaParamFilter;
 import ca.derekcormier.recipe.generator.filter.JavaTypeFilter;
 import ca.derekcormier.recipe.generator.filter.JavaValueFilter;
@@ -11,8 +13,11 @@ public abstract class JavaCookbookGenerator extends CookbookGenerator {
         super(cookbook);
 
         Filter javaTypeFilter = new JavaTypeFilter(cookbook);
+        Filter javaIdentifierFilter = new JavaIdentifierFilter();
         Filter.registerFilter(javaTypeFilter);
-        Filter.registerFilter(new JavaParamFilter(cookbook, javaTypeFilter));
+        Filter.registerFilter(javaIdentifierFilter);
+        Filter.registerFilter(new JavaParamFilter(cookbook, javaTypeFilter, javaIdentifierFilter));
         Filter.registerFilter(new JavaValueFilter(cookbook));
+        Filter.registerFilter(new JavaGetterFilter());
     }
 }

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/TypeScriptCookbookGenerator.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/TypeScriptCookbookGenerator.java
@@ -2,6 +2,7 @@ package ca.derekcormier.recipe.generator;
 
 import ca.derekcormier.recipe.cookbook.Cookbook;
 import ca.derekcormier.recipe.generator.filter.JsParamFilter;
+import ca.derekcormier.recipe.generator.filter.TsIdentifierFilter;
 import ca.derekcormier.recipe.generator.filter.TsParamFilter;
 import ca.derekcormier.recipe.generator.filter.TsTypeFilter;
 import ca.derekcormier.recipe.generator.filter.TsValueFilter;
@@ -12,9 +13,12 @@ public abstract class TypeScriptCookbookGenerator extends CookbookGenerator {
         super(cookbook);
 
         Filter tsTypeFilter = new TsTypeFilter(cookbook);
+        Filter tsIdentifierFilter = new TsIdentifierFilter();
         Filter.registerFilter(tsTypeFilter);
-        Filter.registerFilter(new TsParamFilter(cookbook, tsTypeFilter));
+        Filter.registerFilter(new TsParamFilter(cookbook, tsTypeFilter, tsIdentifierFilter));
         Filter.registerFilter(new TsValueFilter(cookbook));
-        Filter.registerFilter(new JsParamFilter(cookbook));
+        Filter.registerFilter(new JsParamFilter(cookbook, tsIdentifierFilter));
+        Filter.registerFilter(new TsIdentifierFilter());
+        Filter.registerFilter(tsIdentifierFilter);
     }
 }

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/filter/JavaGetterFilter.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/filter/JavaGetterFilter.java
@@ -1,0 +1,42 @@
+package ca.derekcormier.recipe.generator.filter;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import liqp.filters.Filter;
+
+public class JavaGetterFilter extends Filter {
+    private static String[] objectMethodNames;
+
+    static {
+        objectMethodNames = Arrays.stream(Object.class.getMethods()).map(m -> m.getName()).collect(Collectors.toList()).toArray(new String[0]);
+        Arrays.sort(objectMethodNames);
+    }
+
+    public JavaGetterFilter() {
+        super("javagetter");
+    }
+
+    @Override
+    public Object apply(Object value, Object... params) {
+        Map<String,Object> param = (Map<String,Object>)value;
+        String name = (String)param.get("name");
+        String type = (String)param.get("type");
+        boolean compound = param.containsKey("compound") && (boolean)param.get("compound");
+
+        name = name.substring(0, 1).toUpperCase() + name.substring(1);
+
+        if (!compound && (type.equals("boolean") || type.equals("flag"))) {
+            value = "is" + name;
+        }
+        else {
+            value = "get" + name;
+        }
+
+        if (Arrays.binarySearch(objectMethodNames, value) >= 0) {
+            value += "_";
+        }
+        return value;
+    }
+}

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/filter/JavaIdentifierFilter.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/filter/JavaIdentifierFilter.java
@@ -1,0 +1,28 @@
+package ca.derekcormier.recipe.generator.filter;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import liqp.filters.Filter;
+
+public class JavaIdentifierFilter extends Filter {;
+    private static final Set<String> JAVA_KEYWORDS = new HashSet<>();
+
+    static {
+        Collections.addAll(JAVA_KEYWORDS, "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const",
+            "continue", "default", "do", "double", "else", "enum", "extends", "false", "final", "finally", "float", "for", "goto", "if",
+            "implements", "import", "instanceof", "int", "interface", "long", "native", "new", "null", "package", "private", "protected",
+            "public", "return", "short", "static", "strictfp", "super", "switch", "synchronized", "this", "throw", "throws", "transient",
+            "true", "try", "void", "volatile", "while");
+    }
+
+    public JavaIdentifierFilter() {
+        super("javaidentifier");
+    }
+
+    @Override
+    public Object apply(Object value, Object... params) {
+        return JAVA_KEYWORDS.contains(value) ? "_" + value : value;
+    }
+}

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/filter/JavaParamFilter.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/filter/JavaParamFilter.java
@@ -7,10 +7,12 @@ import liqp.filters.Filter;
 
 public class JavaParamFilter extends RecipeFilter {
     private final Filter typeFilter;
+    private final Filter identifierFilter;
 
-    public JavaParamFilter(Cookbook cookbook, Filter typeFilter) {
+    public JavaParamFilter(Cookbook cookbook, Filter typeFilter, Filter identifierFilter) {
         super("javaparam", cookbook);
         this.typeFilter = typeFilter;
+        this.identifierFilter = identifierFilter;
     }
 
     @Override
@@ -19,6 +21,6 @@ public class JavaParamFilter extends RecipeFilter {
         String name = (String)param.get("name");
 
         boolean varargAsArray = params.length > 0 && super.asBoolean(params[0]);
-        return typeFilter.apply(param.get("type"), varargAsArray)  + " " + name;
+        return typeFilter.apply(param.get("type"), varargAsArray)  + " " + identifierFilter.apply(name);
     }
 }

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/filter/JsParamFilter.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/filter/JsParamFilter.java
@@ -5,10 +5,14 @@ import java.util.Map;
 import ca.derekcormier.recipe.cookbook.Cookbook;
 import ca.derekcormier.recipe.cookbook.CookbookUtils;
 import ca.derekcormier.recipe.cookbook.type.ParamType;
+import liqp.filters.Filter;
 
 public class JsParamFilter extends RecipeFilter {
-    public JsParamFilter(Cookbook cookbook) {
+    private final Filter identifierFilter;
+
+    public JsParamFilter(Cookbook cookbook, Filter identifierFilter) {
         super("jsparam", cookbook);
+        this.identifierFilter = identifierFilter;
     }
 
     @Override
@@ -17,6 +21,6 @@ public class JsParamFilter extends RecipeFilter {
         String name = param.get("name");
         ParamType type = CookbookUtils.parseType(param.get("type"), getCookbook());
 
-        return (type.isVararg() ? "..." : "") + name;
+        return (type.isVararg() ? "..." : "") + identifierFilter.apply(name);
     }
 }

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/filter/TsIdentifierFilter.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/filter/TsIdentifierFilter.java
@@ -1,0 +1,28 @@
+package ca.derekcormier.recipe.generator.filter;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import liqp.filters.Filter;
+
+public class TsIdentifierFilter extends Filter {
+    public static final Set<String> TYPESCRIPT_KEYWORDS = new HashSet<>();
+
+    static {
+        Collections.addAll(TYPESCRIPT_KEYWORDS, "any", "as", "boolean", "break", "case", "catch", "class", "const",
+            "constructor", "continue", "debugger", "declare", "default", "delete", "do", "else", "enum", "export", "extends", "false",
+            "finally", "for", "from", "function", "get", "if", "implements", "import", "in", "instanceof", "interface", "let", "module",
+            "new", "null", "number", "of", "package", "private", "protected", "public", "require", "return", "set", "static", "string",
+            "super", "switch", "symbol", "this", "throw", "true", "try", "type", "typeof", "var", "void", "while", "with", "yield");
+    };
+
+    public TsIdentifierFilter() {
+        super("tsidentifier");
+    }
+
+    @Override
+    public Object apply(Object value, Object... params) {
+        return TYPESCRIPT_KEYWORDS.contains(value) ? "_" + value : value;
+    }
+}

--- a/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/filter/TsParamFilter.java
+++ b/recipe-generator/src/main/java/ca/derekcormier/recipe/generator/filter/TsParamFilter.java
@@ -9,10 +9,12 @@ import liqp.filters.Filter;
 
 public class TsParamFilter extends RecipeFilter {
     private final Filter typeFiler;
+    private final Filter identifierFilter;
 
-    public TsParamFilter(Cookbook cookbook, Filter typeFilter) {
+    public TsParamFilter(Cookbook cookbook, Filter typeFilter, Filter identifierFilter) {
         super("tsparam", cookbook);
         this.typeFiler = typeFilter;
+        this.identifierFilter = identifierFilter;
     }
 
     @Override
@@ -21,6 +23,6 @@ public class TsParamFilter extends RecipeFilter {
         String name = param.get("name");
         ParamType type = CookbookUtils.parseType(param.get("type"), getCookbook());
 
-        return (type.isVararg() ? "..." : "") + name + ": " + typeFiler.apply(param.get("type"));
+        return (type.isVararg() ? "..." : "") + identifierFilter.apply(name) + ": " + typeFiler.apply(param.get("type"));
     }
 }

--- a/recipe-generator/src/main/resources/templates/java/ingredient-data.liquid
+++ b/recipe-generator/src/main/resources/templates/java/ingredient-data.liquid
@@ -6,7 +6,8 @@
 {%- if options.javaPackage != "" -%}
 package {{options.javaPackage}};
 {% endif %}
-{%- assign dataClassName = ingredient.name | append: 'Data' -%}
+import com.fasterxml.jackson.annotation.JsonProperty;
+{% assign dataClassName = ingredient.name | append: 'Data' -%}
 import ca.derekcormier.recipe.{{superclass}};
 
 public class {{dataClassName}} extends {{superclass}} {
@@ -15,11 +16,11 @@ public class {{dataClassName}} extends {{superclass}} {
     }
 
     {%- for required in ingredient.required %}
-    public {{required.type | javatype:true}} {% if required.type != 'boolean' %}get{% else %}is{% endif %}{{required.name | capitalize}}() {
+    public {{required.type | javatype:true}} {{required | javagetter}}() {
         return getProperty("{{required.name}}");
     }
     public void set{{required.name | capitalize}}({{required | javaparam}}) {
-        setProperty("{{required.name}}", {{required.name}});
+        setProperty("{{required.name}}", {{required.name | javaidentifier}});
     }
     {%- endfor %}
     {%- for optional in ingredient.optionals %}
@@ -27,18 +28,18 @@ public class {{dataClassName}} extends {{superclass}} {
         return hasProperty("{{optional.name}}");
     }
         {%- if optional.compound != true %}
-    public {{optional.type | javatype:true}}{% if optional.repeatable == true %}[]{% endif %} {% if optional.type != 'boolean' and optional.type != 'flag' %}get{% else %}is{% endif %}{{optional.name | capitalize}}() {
+    public {{optional.type | javatype:true}}{% if optional.repeatable == true %}[]{% endif %} {{optional | javagetter}}() {
         return getProperty({{optional.type | javatype:true}}{% if optional.repeatable == true %}[]{% endif %}.class, "{{optional.name}}");
     }
-    public void set{{optional.name | capitalize}}({{optional.type | javatype:true}}{% if optional.repeatable == true %}[]{% endif %} {{optional.name}}) {
-        setProperty("{{optional.name}}", {{optional.name}});
+    public void set{{optional.name | capitalize}}({{optional.type | javatype:true}}{% if optional.repeatable == true %}[]{% endif %} {{optional.name | javaidentifier}}) {
+        setProperty("{{optional.name}}", {{optional.name | javaidentifier}});
     }
         {%- else -%}
-    public {{optional.name | capitalize}}Params{% if optional.repeatable == true %}[]{% endif %} get{{optional.name | capitalize}}() {
+    public {{optional.name | capitalize}}Params{% if optional.repeatable == true %}[]{% endif %} {{optional | javagetter}}() {
         return getProperty({{optional.name | capitalize}}Params{% if optional.repeatable == true %}[]{% endif %}.class, "{{optional.name}}");
     }
-    public void set{{optional.name | capitalize}}({{optional.name | capitalize}}Params{% if optional.repeatable == true %}[]{% endif %} {{optional.name}}) {
-        setProperty("{{optional.name}}", {{optional.name}});
+    public void set{{optional.name | capitalize}}({{optional.name | capitalize}}Params{% if optional.repeatable == true %}[]{% endif %} {{optional.name | javaidentifier}}) {
+        setProperty("{{optional.name}}", {{optional.name | javaidentifier}});
     }
         {% endif %}
     {%- endfor %}
@@ -46,6 +47,7 @@ public class {{dataClassName}} extends {{superclass}} {
         {%- if optional.compound %}
     public static class {{optional.name | capitalize}}Params {
             {%- for param in optional.params %}
+        @JsonProperty("{{param.name}}")
         public {{param | javaparam:true}};
             {%- endfor %}
     }{%- endif %}

--- a/recipe-generator/src/main/resources/templates/java/ingredient.liquid
+++ b/recipe-generator/src/main/resources/templates/java/ingredient.liquid
@@ -31,7 +31,7 @@ public class {{ingredientName}} extends {{superclass}} {
         super("{{ingredient.name}}", "{{domain}}");
         {%- for required in ingredient.required %}
             {%- if initializer.params contains required.name %}
-        setRequired("{{required.name}}", {{required.name}});
+        setRequired("{{required.name}}", {{required.name | javaidentifier}});
             {%- else %}
         setRequired("{{required.name}}", {{required.default | javavalue:required.type}});
             {%- endif -%}
@@ -72,14 +72,14 @@ public class {{ingredientName}} extends {{superclass}} {
         {{ingredientName}} copy = new {{ingredientName}}(this);
         {%- if optional.compound != true -%}
             {%- if optional.type != 'flag' %}
-        copy.setOptional("{{optional.name}}", {{optional.repeatable}}, {{optional.name}});
+        copy.setOptional("{{optional.name}}", {{optional.repeatable}}, {{optional.name | javaidentifier}});
             {%- else %}
         copy.setOptional("{{optional.name}}", {{optional.repeatable}}, true);
             {%- endif -%}
         {%- else %}
         copy.setCompoundOptional("{{optional.name}}", {{optional.repeatable}}
         {%- for param in optional.params -%}
-        , "{{param.name}}", {{param.name}}
+        , "{{param.name}}", {{param.name | javaidentifier}}
         {%- endfor -%});
         {%- endif %}
         return copy;

--- a/recipe-generator/src/main/resources/templates/ts/ingredient.liquid
+++ b/recipe-generator/src/main/resources/templates/ts/ingredient.liquid
@@ -67,14 +67,14 @@ class {{ingredientName}} extends {{superclass}} {
         const copy = this.duplicate();
         {%- if optional.compound != true -%}
             {%- if optional.type != 'flag' %}
-        copy.setOptional("{{optional.name}}", {{optional.repeatable}}, {{optional.name}});
+        copy.setOptional("{{optional.name}}", {{optional.repeatable}}, {{optional.name | tsidentifier}});
             {%- else %}
         copy.setOptional("{{optional.name}}", {{optional.repeatable}}, true);
             {%- endif -%}
         {%- else %}
         copy.setCompoundOptional("{{optional.name}}", {{optional.repeatable}}
         {%- for param in optional.params -%}
-        , "{{param.name}}", {{param.name}}
+        , "{{param.name}}", {{param.name | tsidentifier}}
         {%- endfor -%});
         {%- endif %}
         return copy;

--- a/recipe-generator/src/test/java/ca/derekcormier/recipe/generator/filter/JavaGetterFilterTest.java
+++ b/recipe-generator/src/test/java/ca/derekcormier/recipe/generator/filter/JavaGetterFilterTest.java
@@ -1,0 +1,46 @@
+package ca.derekcormier.recipe.generator.filter;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class JavaGetterFilterTest {
+    @Test
+    public void testApply_prependsGetToParamName() {
+        JavaGetterFilter filter = new JavaGetterFilter();
+
+        assertEquals("getFoobar", filter.apply(param("foobar", "int")));
+    }
+
+    @Test
+    public void testApply_prependsIsForBooleanParam() {
+        JavaGetterFilter filter = new JavaGetterFilter();
+
+        assertEquals("isFoobar", filter.apply(param("foobar", "boolean")));
+    }
+
+    @Test
+    public void testApply_prependsIsForFlagParam() {
+        JavaGetterFilter filter = new JavaGetterFilter();
+
+        assertEquals("isFoobar", filter.apply(param("foobar", "flag")));
+    }
+
+    @Test
+    public void testApply_sanitizesMethodNameIfMethodExistsOnJavaObjectClass() {
+        JavaGetterFilter filter = new JavaGetterFilter();
+
+        assertEquals("getClass_", filter.apply(param("class", "string")));
+    }
+
+    private Map<String,Object> param(String name, String type) {
+        Map<String,Object> value = new HashMap<>();
+        value.put("name", name);
+        value.put("type", type);
+
+        return value;
+    }
+}

--- a/recipe-generator/src/test/java/ca/derekcormier/recipe/generator/filter/JavaIdentifierFilterTest.java
+++ b/recipe-generator/src/test/java/ca/derekcormier/recipe/generator/filter/JavaIdentifierFilterTest.java
@@ -1,0 +1,23 @@
+package ca.derekcormier.recipe.generator.filter;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import liqp.filters.Filter;
+
+public class JavaIdentifierFilterTest {
+    @Test
+    public void testApply_sanitizesValueIfJavaKeyword() {
+        Filter filter = new JavaIdentifierFilter();
+
+        assertEquals("_class", filter.apply("class"));
+    }
+
+    @Test
+    public void testApply_doesNotSanitizeNonJavaKeywords() {
+        Filter filter = new JavaIdentifierFilter();
+
+        assertEquals("foobar", filter.apply("foobar"));
+    }
+}

--- a/recipe-generator/src/test/java/ca/derekcormier/recipe/generator/filter/JavaParamFilterTest.java
+++ b/recipe-generator/src/test/java/ca/derekcormier/recipe/generator/filter/JavaParamFilterTest.java
@@ -20,25 +20,28 @@ import liqp.filters.Filter;
 public class JavaParamFilterTest {
     @Mock
     private JavaTypeFilter javaTypeFilter;
+    @Mock
+    private JavaIdentifierFilter javaIdentifierFilter;
 
     @Test
-    public void testApply_combinesTypeFromTypeFilterWithName() {
+    public void testApply_combinesTypeAndNameFromFilters() {
         Cookbook cookbook = new Cookbook(new ArrayList<>(), new ArrayList<>());
-        Filter filter = new JavaParamFilter(cookbook, javaTypeFilter);
+        Filter filter = new JavaParamFilter(cookbook, javaTypeFilter, javaIdentifierFilter);
 
         Map param = new HashMap();
         param.put("name", "foo");
         param.put("type", "int[]");
 
         when(javaTypeFilter.apply(param.get("type"), false)).thenReturn("type");
+        when(javaIdentifierFilter.apply(param.get("name"))).thenReturn("identifier");
 
-        assertEquals("type foo", filter.apply(param));
+        assertEquals("type identifier", filter.apply(param));
     }
 
     @Test
     public void testApply_passesCollapseVarargOptionToTypeFilter() {
         Cookbook cookbook = new Cookbook(new ArrayList<>(), new ArrayList<>());
-        Filter filter = new JavaParamFilter(cookbook, javaTypeFilter);
+        Filter filter = new JavaParamFilter(cookbook, javaTypeFilter, javaIdentifierFilter);
 
         Map param = new HashMap();
         param.put("name", "foo");

--- a/recipe-generator/src/test/java/ca/derekcormier/recipe/generator/filter/JsParamFilterTest.java
+++ b/recipe-generator/src/test/java/ca/derekcormier/recipe/generator/filter/JsParamFilterTest.java
@@ -1,8 +1,12 @@
 package ca.derekcormier.recipe.generator.filter;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -11,19 +15,26 @@ import java.util.Map;
 import ca.derekcormier.recipe.cookbook.Cookbook;
 import liqp.filters.Filter;
 
+@RunWith(MockitoJUnitRunner.class)
 public class JsParamFilterTest {
-    @Test
-    public void testApply_outputsParamName() {
-        Cookbook cookbook = new Cookbook(new ArrayList<>(), new ArrayList<>());
-        Filter filter = new JsParamFilter(cookbook);
+    @Mock
+    private TsIdentifierFilter identifierFilter;
 
-        assertEquals("foo", filter.apply(param("foo", "string")));
+    @Test
+    public void testApply_outputsParamNameFromIdentifierFilter() {
+        Cookbook cookbook = new Cookbook(new ArrayList<>(), new ArrayList<>());
+        Filter filter = new JsParamFilter(cookbook, identifierFilter);
+        when(identifierFilter.apply("foo")).thenReturn("bar");
+
+        assertEquals("bar", filter.apply(param("foo", "string")));
     }
 
     @Test
     public void testApply_outputsEllipsesWhenParamTypeIsVararg() {
         Cookbook cookbook = new Cookbook(new ArrayList<>(), new ArrayList<>());
-        Filter filter = new JsParamFilter(cookbook);
+        Filter filter = new JsParamFilter(cookbook, identifierFilter);
+        when(identifierFilter.apply("foo")).thenReturn("foo");
+
 
         assertEquals("...foo", filter.apply(param("foo", "int...")));
     }

--- a/recipe-generator/src/test/java/ca/derekcormier/recipe/generator/filter/TsIdentifierFilterTest.java
+++ b/recipe-generator/src/test/java/ca/derekcormier/recipe/generator/filter/TsIdentifierFilterTest.java
@@ -1,0 +1,21 @@
+package ca.derekcormier.recipe.generator.filter;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TsIdentifierFilterTest {
+    @Test
+    public void testApply_sanitizesValueIfTypeScriptKeyword() {
+        TsIdentifierFilter filter = new TsIdentifierFilter();
+
+        assertEquals("_number", filter.apply("number"));
+    }
+
+    @Test
+    public void testApply_doesNotSanitizeNonTypeScriptKeywords() {
+        TsIdentifierFilter filter = new TsIdentifierFilter();
+
+        assertEquals("foobar", filter.apply("foobar"));
+    }
+}


### PR DESCRIPTION
@jbedard 

This is a fix for https://github.com/kormide/recipe/issues/50. In certain cases, ingredient parameter names specified in the yaml config end up as identifiers. For example, a generated Java ingredient could have a method like:

```
public MyIngredient withX(int x) {
...
}
```

This breaks down when `x` is a Java keyword and we are generating Java code (ditto with TypeScript). I don't want to just prevent using keywords for the name of parameters, since I'd have to ban all keywords for all languages that recipe supports in the future, and that seems too restrictive.

In cases where the identifier conflicts with the language in which the ingredient is generated, I just decorate it with `_`. For example:

```
public MyIngredient withClass(int _class) {
...
}
```

This doesn't change the actual internal name of the parameter. It will still be `class` in any json that gets sent around. It also doesn't change any methods in the public interface. In the worst case you'd just see the odd underscore in your IDEs parameter hint list.

This is NOT ready to merge. Still have a number of tests to add.